### PR TITLE
fix: Render signature canvas when user has saved profile

### DIFF
--- a/pretix_signature_question/static/pretix_signature_question/main.js
+++ b/pretix_signature_question/static/pretix_signature_question/main.js
@@ -20,7 +20,7 @@ $(function () {
         var $signature = $("<div>")
         $input.closest("div").append($signature);
         $signature.jSignature('init', {
-            'width': $(".questions-form .col-md-9").width()
+            'width': $input.closest(".col-md-9").width()
         });
 
         var $reset = $("<button>").attr("type", "button").attr("class", "btn btn-default")


### PR DESCRIPTION
Hi all! I ran into this issue when testing our Pretix instance with this plugin.

Full disclosure: I worked with Claude to identify the issue in the plugin code after trying to write some custom javascript overrides in our pretix instance failed to work.

Testing: We've deployed this fix to our production instance and have verified that it works (on pretix 2026.04, along with the fixes detailed in https://github.com/pretix/pretix/issues/6123).

## Initial prompt to claude

<details>
We're running Pretix and we are encountering an issue where some users are seeing the page render differently than other users. It's not a browser or cache issue - I can replicate the issue on the same browser/system by logging in as different users.

The issue is with the signature question (code in pretix/pretix-signature-question). For some users, when one signature question is used in a product, the signature question renders with the following HTML:


```
<div class="form-group required"><label class="col-md-3 control-label" data-identifier="G33HPHVF" for="id_1695-question_134">Liability Waiver Signature<i class="label-required">required</i></label><div class="col-md-9"><div class="help-block" id="help-for-id_1695-question_134-0"><p>By signing, I acknowledge that I have received, read, understand, and agree to comply with the <a href="/redirect/?url=http%3A//go.lunaburn.org/liability-waiver%3As8ovbfdR49QqOItMvL21V3uP3apYeKZ0WR190YiVFeE" rel="noopener" target="_blank">Luna Burn Liability Waiver</a>.</p></div><div class="row bootstrap3-multi-input"><div class="col-xs-12"><input type="file" name="1695-question_134" class="" title="By signing, I acknowledge that I have received, read, understand, and agree to comply with the Luna Burn Liability Waiver." aria-describedby="help-for-id_1695-question_134-0" required="" id="id_1695-question_134" style="display: none;"><div><div style="padding:0 !important;margin:0 !important;width: 100% !important; height: 0 !important;margin-top:-1em !important;margin-bottom:1em !important;"></div><canvas class="jSignature" width="658" style="margin: 0px; padding: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; height: 165px; width: 658.5px;" height="165"></canvas><div style="padding:0 !important;margin:0 !important;width: 100% !important; height: 0 !important;margin-top:-1.5em !important;margin-bottom:1.5em !important;"></div></div><button type="button" class="btn btn-default">Reset</button></div></div></div></div>
```


But for others, the question renders with a canvas height hard-coded to 0 ( `height: 0px; width: 0px;`)


```
<div class="form-group required"><label class="col-md-3 control-label" data-identifier="G33HPHVF" for="id_1690-question_134">Liability Waiver Signature<i class="label-required">required</i></label><div class="col-md-9"><div class="help-block" id="help-for-id_1690-question_134-0"><p>By signing, I acknowledge that I have received, read, understand, and agree to comply with the <a href="/redirect/?url=http%3A//go.lunaburn.org/liability-waiver%3As8ovbfdR49QqOItMvL21V3uP3apYeKZ0WR190YiVFeE" rel="noopener" target="_blank">Luna Burn Liability Waiver</a>.</p></div><div class="row bootstrap3-multi-input"><div class="col-xs-12"><input type="file" name="1690-question_134" class="" title="By signing, I acknowledge that I have received, read, understand, and agree to comply with the Luna Burn Liability Waiver." aria-describedby="help-for-id_1690-question_134-0" required="" id="id_1690-question_134" style="display: none;"><div><div style="padding:0 !important;margin:0 !important;width: 100% !important; height: 0 !important;margin-top:-1em !important;margin-bottom:1em !important;"></div><canvas style="margin: 0px; padding: 0px; border-width: medium; border-style: none; border-color: currentcolor; border-image: initial; height: 0px; width: 0px;" class="jSignature" width="0" height="0"></canvas><div style="padding:0 !important;margin:0 !important;width: 100% !important; height: 0 !important;margin-top:-1.5em !important;margin-bottom:1.5em !important;"></div></div><button type="button" class="btn btn-default">Reset</button></div></div></div></div>
```

I'm having trouble resolving this. It seems like the issue has to do with rendering order, but I don't have control over when jsignature is loaded on the page. Further, it's very confusing that this renders properly for _some_ logged in users but not others.

</details>

## Reported issue summary

The `pretix-signature-question` plugin was rendering inconsistently across users on the same browser and machine. Some users saw the signature canvas at its expected size (around 658px wide); others saw it collapsed to `width="0" height="0"` with the inline style `height: 0px; width: 0px;`. Because the input was hidden (`display: none`) and replaced by a zero-sized canvas, those users effectively had no usable signature widget. The same browser session would produce a working canvas for one logged-in user and a broken one for another, so caching, browser quirks, and locale all looked unlikely.

## Where the bug actually lives

The plugin's `main.js` initializes jSignature once for every signature-bearing form group on the questions page. It calls jSignature with an explicit width:

```js
$signature.jSignature('init', {
    'width': $(".questions-form .col-md-9").width()
});
```

That selector returns the *first* `.col-md-9` element inside any `.questions-form` on the page. When jQuery's `.width()` is called on a hidden element (or one inside a hidden ancestor), it returns `0`. jSignature derives a 4:1 height from the width it's given, so width 0 produces a 0×0 canvas. Since the same width value is used for every signature on the page, all canvases on a broken page would render at zero — the bug isn't per-canvas, it's per-page.

## Why it depended on which user was logged in

Pretix's `checkout_questions.html` template renders an "Auto-fill with address" block at the top of each position's form, but only when the customer has saved address profiles attached to their account:

```django
{% if profiles_data %}
    <div class="form-group profile-select-container js-do-not-copy-answers">
        <label class="col-md-3 control-label" ...>Auto-fill with address</label>
        <div class="col-md-9"> ... </div>
    </div>
{% endif %}
```

That `.profile-select-container` ships with `display: none` in `_checkout.scss` (line 142) and is only made visible after Pretix's own `questions.js` runs `questions_init_profiles($("body"))` and adds the `profile-select-initialized` class to the scope. The plugin's own `$(function () { ... })` registers earlier in DOM-ready order, so when `main.js` reads the page width, the profile-select container hasn't yet been un-hidden.

The data dependency falls out cleanly:

- A user with **saved profiles** has the hidden `.profile-select-container > .col-md-9` as the first matching column on the page. `.width()` returns 0, jSignature is initialized with width 0, the canvas comes out 0×0.
- A user with **no saved profiles** has the entire `{% if profiles_data %}` block omitted from the rendered HTML. The first `.col-md-9` on the page is now a real, visible question column. `.width()` returns the actual column width, the canvas renders correctly.

That perfectly matches the "logging in as different users on the same browser produces different rendering" symptom: the page itself differs based on what's on the user's account, not on browser state.

## The fix

The selector was reaching across the whole page when it only ever needed the column belonging to *this* signature input. The signature's file input always sits inside its own `.col-md-9` (the right-hand column of its `.form-group`), and that column is never inside a `display:none` container — so measuring it directly is correct in both user cases:

```js
$signature.jSignature('init', {
    'width': $input.closest(".col-md-9").width()
});
```

This sidesteps the original race entirely. The plugin no longer cares whether `.profile-select-container` exists, whether `.profile-select-initialized` has been applied yet, or in what order the various DOM-ready callbacks fire. Each canvas is sized from its own column, which is always rendered and visible at the moment `main.js` runs.
